### PR TITLE
Update PIPpolarize.nlogo

### DIFF
--- a/PIPpolarize.nlogo
+++ b/PIPpolarize.nlogo
@@ -253,6 +253,12 @@ to go
   if save-dir-name != "N/A" and not file-exists? (word save-dir-name "iface-t0 " file-prefix ".png") ; Trying to find the screenshot of the initial interface taken at "setup".
   [ user-message "save-dir-name (probably) changed since \"setup\"" set save-dir-name "N/A" set setup-success? false stop ] ; If it's not found, tell the user that probably, you changed the save-dir after you pressed "setup"
 
+
+  if "no" = user-one-of (word "Saving result file(s) to " save-dir-name " - Okay?") ["yes" "no"]
+    [stop]
+
+
+
   ; Check stop-conditions and apply necessary ending steps
   if time > endtime
   [


### PR DESCRIPTION
Ask the user if saving result files into the save-dir-name is okay.

This is added because user often unconsciously save result files if the saving option(s) is(/are) "on".